### PR TITLE
wip-fix(avatar): improve avatar to work with firefox

### DIFF
--- a/gulp/tasks/css-compile.js
+++ b/gulp/tasks/css-compile.js
@@ -31,7 +31,12 @@ gulp.task('css-compile', function cssCompile() {
       lost()
     ]))
     .pipe(autoprefixer())
-    .pipe(cleanCSS({compatibility: 'ie8'}))
+    .pipe(cleanCSS({
+      compatibility: 'ie8',
+      advanced: {
+        mergeAdjacent: false
+      }
+    }))
     .pipe(sourcemaps.write('./source_mapping', {
       includeContent: true,
       sourceRoot: '.',

--- a/src/assets/skin/orga_mask.svg
+++ b/src/assets/skin/orga_mask.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
 <path d="M16,0.6L2.7,8.3v15.4L16,31.4l13.3-7.7V8.3L16,0.6z"/>
 </svg>

--- a/src/components/elements/avatar/Avatar.js
+++ b/src/components/elements/avatar/Avatar.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var classnames = require('classnames');
+var InlineSVG = require('svg-inline-react');
 
 var Avatar = React.createClass({
   displayName: 'Avatar',
@@ -36,6 +37,21 @@ var Avatar = React.createClass({
     return img;
   },
 
+  renderSvg: function() {
+    if (this.props.format !== 'org') {
+      return null;
+    }
+    return (
+      <svg width="0" height="0">
+        <defs>
+          <clipPath id="clip-shape" clipPathUnits="objectBoundingBox">
+            <polygon points="0.5 0.019, 0.084 0.26, 0.084 0.74, 0.5 0.98, 0.91 0.74, 0.91 0.26, 0.5 0.019" />
+          </clipPath>
+        </defs>
+      </svg>
+    );
+  },
+
   render: function() {
     var classes = [ 'Avatar' ];
 
@@ -54,6 +70,7 @@ var Avatar = React.createClass({
     return (
       <div {...this.props} className={classnames(classes)}>
         { this.renderImg() }
+        { this.renderSvg() }
       </div>
     );
   }

--- a/src/components/elements/avatar/Avatar.styl
+++ b/src/components/elements/avatar/Avatar.styl
@@ -60,10 +60,15 @@ $Avatar = {
       width: unit($Avatar.sizes.org[2][0],'px');
       height: unit($Avatar.sizes.org[2][1],'px');
     }
+
     .Avatar__image {
-      mask: url("/assets/skin/orga_mask.svg");
-      mask-box-image: url("/assets/skin/orga_mask.svg");
-      mask-repeat: no-repeat;
+      /* autoprefixer: off */
+      -webkit-clip-path: url("#clip-shape"); /* required for Webkit/Blink browsers if you're using only inline SVG clipping paths, but not CSS clip-path */
+      -webkit-clip-path: polygon(50% 1.9%, 8.4% 26%, 8.4% 74%, 50% 98%, 91% 74%, 91% 26%, 50% 1.9%);
+
+      clip-path: polygon(50% 1.9%, 8.4% 26%, 8.4% 74%, 50% 98%, 91% 74%, 91% 26%, 50% 1.9%);
+      clip-path: url("#clip-shape");
+      /* autoprefixer: on */
     }
   }
 }


### PR DESCRIPTION
React 0.13 ne permet pas de gérer clipPath
A tester, peut être avec le SVG inséré par défaut mais j'ai pas réussi

CF: https://github.com/esbullington/react-d3/issues/117