### PR TITLE
ftr(package): update react-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react": "^15.3.1",
     "react-addons-update": "^15.3.1",
     "react-dom": "^15.3.1",
-    "react-router": "^2.7.0"
+    "react-router": "^3.0.0"
   },
   "peerDependencies": {
     "formsy-react": "^0.18.1"


### PR DESCRIPTION
NE PAS MERGER 

npm ERR! peerinvalid The package react-router@3.0.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer isomorphic-relay-router@0.8.4 wants react-router@^2.3.0
npm ERR! peerinvalid Peer react-router-relay@0.13.5 wants react-router@>=2.3.0
